### PR TITLE
Autoload Earlier

### DIFF
--- a/src/app/code/community/Cloudinary/Cloudinary/Helper/Autoloader.php
+++ b/src/app/code/community/Cloudinary/Cloudinary/Helper/Autoloader.php
@@ -8,17 +8,24 @@ class Cloudinary_Cloudinary_Helper_Autoloader
     const CONVERT_CLASS_TO_PATH_REGEX = '#\\\|_(?!.*\\\)#';
 
     private $_originalAutoloaders;
+    static protected $_isRegistered = false;
 
     public function register()
     {
+        if (self::$_isRegistered) {
+            return;
+        }
         $this->_deregisterVarienAutoloaders();
         $this->_registerCloudinaryAutoloader();
         $this->_registerCloudinaryExtensionAutoloader();
         $this->_reregisterVarienAutoloaders();
+
+        self::$_isRegistered = true;
     }
 
     private function _registerCloudinaryExtensionAutoloader()
     {
+
         spl_autoload_register(
             function ($className) {
                 if(
@@ -68,4 +75,4 @@ class Cloudinary_Cloudinary_Helper_Autoloader
             spl_autoload_register($autoloader);
         }
     }
-} 
+}

--- a/src/app/code/community/Cloudinary/Cloudinary/etc/config.xml
+++ b/src/app/code/community/Cloudinary/Cloudinary/etc/config.xml
@@ -92,7 +92,7 @@
                     </delete_images_from_cloudinary>
                 </observers>
             </catalog_product_save_before>
-            <controller_front_init_before>
+            <resource_get_tablename>
                 <observers>
                     <load_custom_autoloaders>
                         <type>singleton</type>
@@ -100,7 +100,7 @@
                         <method>loadCustomAutoloaders</method>
                     </load_custom_autoloaders>
                 </observers>
-            </controller_front_init_before>
+            </resource_get_tablename>
         </events>
         <resources>
             <cloudinary_setup>


### PR DESCRIPTION
Currently this extension registers it's autoloaders on the Magento event `controller_front_init_before`.

The disadvantage with this is it's not run all the time, namely cron jobs and shell scripts. I'm using both when dealing with Products and their associated images.

A good rundown of autoloading in Magento is here
http://www.webguys.de/magento/tuerchen-11-the-magento-autoloader-and-external-libraries/

This PR hooks into a much earlier event, but as the above article says it's run an awful lot so I've added a quick check to not register if we're already loaded. This should mean that every request is will have the autoloaders registered.
