### PR TITLE
Make logging configurable

### DIFF
--- a/src/app/code/community/Cloudinary/Cloudinary/Model/Logger.php
+++ b/src/app/code/community/Cloudinary/Cloudinary/Model/Logger.php
@@ -6,17 +6,23 @@ class Cloudinary_Cloudinary_Model_Logger extends Mage_Core_Model_Abstract implem
 
     public function warning($message, array $context = array())
     {
-        Mage::log($message, Zend_Log::WARN);
+        if ($this->isActive()) {
+            Mage::log($message, Zend_Log::WARN, $this->getFilename());
+        }
     }
 
     public function notice($message, array $context = array())
     {
-        Mage::log($message, Zend_Log::NOTICE);
+        if ($this->isActive()) {
+            Mage::log($message, Zend_Log::NOTICE, $this->getFilename());
+        }
     }
 
     public function error($message, array $context = array())
     {
-        Mage::log($message, Zend_Log::ERR);
+        if ($this->isActive()) {
+            Mage::log($message, Zend_Log::ERR, $this->getFilename());
+        }
     }
 
     public function debugLog($message)
@@ -44,5 +50,28 @@ class Cloudinary_Cloudinary_Model_Logger extends Mage_Core_Model_Abstract implem
     public static function getInstance()
     {
         return Mage::getModel('cloudinary_cloudinary/logger');
+    }
+
+    /**
+     * check is logging is enabled
+     * @return bool
+     */
+    public function isActive()
+    {
+        return Mage::getStoreConfigFlag('cloudinary/log/actice');
+    }
+
+    /**
+     * return filename where to log data
+     * @return mixed|string
+     */
+    public function getFilename()
+    {
+        $filename = Mage::getStoreConfig('cloudinary/log/filename');
+        if (empty($filename)) {
+            $filename = Mage::getStoreConfig('dev/log/file');
+        }
+
+        return $filename;
     }
 }

--- a/src/app/code/community/Cloudinary/Cloudinary/etc/config.xml
+++ b/src/app/code/community/Cloudinary/Cloudinary/etc/config.xml
@@ -149,6 +149,10 @@
             <configuration>
                 <cloudinary_cdn_subdomain>1</cloudinary_cdn_subdomain>
             </configuration>
+            <log>
+                <active>1</active>
+                <filename>cloudinary.log</filename>
+            </log>
         </cloudinary>
     </default>
     <crontab>

--- a/src/app/code/community/Cloudinary/Cloudinary/etc/system.xml
+++ b/src/app/code/community/Cloudinary/Cloudinary/etc/system.xml
@@ -115,6 +115,25 @@
                         </cloudinary_image_dpr>
                     </fields>
                 </transformations>
+                <log>
+                    <active>
+                        <label>Enable Logging</label>
+                        <frontend_type>select</frontend_type>
+                        <sort_order>1</sort_order>
+                        <show_in_default>1</show_in_default>
+                        <show_in_website>1</show_in_website>
+                        <show_in_store>1</show_in_store>
+                        <source_model>adminhtml/system_config_source_yesno</source_model>
+                    </active>
+                    <filename>
+                        <label>Filename for Logging (default system.xml)</label>
+                        <frontend_type>text</frontend_type>
+                        <sort_order>1</sort_order>
+                        <show_in_default>1</show_in_default>
+                        <show_in_website>1</show_in_website>
+                        <show_in_store>1</show_in_store>
+                    </filename>
+                </log>
             </groups>
         </cloudinary>
     </sections>


### PR DESCRIPTION
The extension heavily polluted the system.log because every single action was logged to the system log. On systems with a large filecount that was quite a mess and grew the logfile size extremly. 
Now the logging can be deactivated in the backend and another logfile can be specified.
