### PR TITLE
Fix a problem with getStorageRoot() yielding the real_path

### DIFF
--- a/src/app/code/community/Cloudinary/Cloudinary/Model/Resource/Cms/Synchronisation/Collection.php
+++ b/src/app/code/community/Cloudinary/Cloudinary/Model/Resource/Cms/Synchronisation/Collection.php
@@ -15,7 +15,7 @@ class Cloudinary_Cloudinary_Model_Resource_Cms_Synchronisation_Collection
 
     public function __construct()
     {
-        $this->addTargetDir(Mage::helper('cms/wysiwyg_images')->getStorageRoot());
+        $this->addTargetDir(Mage::getBaseDir('media').DS.'wysiwyg'.DS);
         $this->setItemObjectClass('cloudinary_cloudinary/cms_synchronisation');
         $this->setFilesFilter(
             sprintf('#^[a-z0-9\.\-\_]+\.(?:%s)$#i', implode('|', $this->allowedImgExtensions))


### PR DESCRIPTION
There was a problem if the media-dir was behind a symlink that caused
wysiwyg images to be synched multiple times becuase the path from the
cloudinary_synchronisation table was always diffrent from the one that
was in the filesystem-collection. Because of this every image was
synched every time the sync tried to run.
